### PR TITLE
Remove the unnecessary css counter for  <ol> in editor css. ( issue #…

### DIFF
--- a/src/editor/components.css
+++ b/src/editor/components.css
@@ -62,12 +62,6 @@
 .public-DraftStyleDefault-ol {
   padding-left: 2.0rem;
   list-style-type: decimal;
-  counter-reset: ol-counter;
-}
-
-.public-DraftStyleDefault-ol:before {
-  content: counter(ol-counter);
-  counter-increment: ol-counter;
 }
 
 .RichEditor-editor .public-DraftEditorPlaceholder-root,


### PR DESCRIPTION
#88 该问题是因为editor的内置样式错误
  
 `<ol></ol>`在渲染时浏览器会自动为其中的`<li></li>`编号，所以不需要手动再加一个counter。
  
（ps: 若不考虑浏览器会自己渲染的问题，content加在了 `ol:before` 应该也是错的，会导致issue所说的有个1的问题，应为`li:before`）